### PR TITLE
Add an option to ignore tests

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -146,10 +146,11 @@ type Config struct {
 	MatchWithConstants bool
 	MinStringLength    int
 	MinOccurrences     int
+	IgnoreTests        bool
 }
 
 func Run(files []*ast.File, fset *token.FileSet, cfg *Config) ([]Issue, error) {
-	p := New("", "", false, cfg.MatchWithConstants, false, cfg.MinStringLength)
+	p := New("", "", cfg.IgnoreTests, cfg.MatchWithConstants, false, cfg.MinStringLength)
 	var issues []Issue
 	for _, f := range files {
 		ast.Walk(&treeVisitor{


### PR DESCRIPTION
Greetings,

I saw that the option to skip tests for `goconst` was missing from `linters-settings` in `golangci/golangci-lint` and the first step towards implementing it was adding it as an option here. Can you please review and (potentially) merge this so i can PR the `golangci/golangci-lint` repo as well? 🙂 

Thanks,
Georgi